### PR TITLE
对齐输入流格式

### DIFF
--- a/es5/client.js
+++ b/es5/client.js
@@ -1731,9 +1731,8 @@ var Client = function () {
                     if (!(data instanceof Uint8Array)) {
                       throw new Error('data must be Uint8Array');
                     }
-                    var messageArray = new Uint8Array(data.length + 1);
-                    messageArray.set([messageStdin]);
-                    messageArray.set(data, 1);
+                    var messageArray = new Uint8Array(data.length);
+                    messageArray.set(data);
                     ws.send(messageArray);
                   }
                 });

--- a/lib/client.js
+++ b/lib/client.js
@@ -1419,9 +1419,8 @@ class Client {
         if (!(data instanceof Uint8Array)) {
           throw new Error('data must be Uint8Array');
         }
-        const messageArray = new Uint8Array(data.length + 1);
-        messageArray.set([messageStdin]);
-        messageArray.set(data, 1);
+        const messageArray = new Uint8Array(data.length);
+        messageArray.set(data);
         ws.send(messageArray);
       }
     };


### PR DESCRIPTION
在部分场景（vim 编辑）下，用于表明输入流格式的 `0x00` 会导致不符合预期行为，在后端实现相关功能前，移除该标识